### PR TITLE
Fixed the explanation on how to access multinote mode and melodic step sequencer

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -583,7 +583,7 @@
 	<section>
 	<h4>Multinote Mode</h4>
 	<p>
-	to activate this mode, press user mode 2 button until it turns green.
+	    To activate this mode, press the 4th scene button while in Combined Mode (pressing the same button again will take you back to Combined Mode).
 	</p>
 	<p>
 		This mode uses the grid as a 8*8 matrix. one midi note per row. it follows the scale mode selected. Note that the left and right arrows are used to navigate left and right in the clip.
@@ -694,6 +694,9 @@
 
 	<section>
 	<h3>Melodic StepSequencer</h3>
+	<p>
+	    To activate this mode, press user mode 2 button until it turns green.
+	</p>
 	<p>
 		This mode behave more how a hardware stepsequencer works. it uses the grid as a 7*8 matrix to edit note pitch, velocity, length and octave. one function per page.
 		of course notes pitches follow the selected scale !


### PR DESCRIPTION
In the previous version it said that to access Multinote mode I have to press user mode 2 button until it turns green: that is not correct, the above explanation is how you access the Melodic step sequencer, not how you access the Multinote mode. In order to access the Multinote you have to go to Combined mode and use the 4th scene button to cycle between Combined and Multinote.

I decided to contribute because I had hard time accessing the Melodic step sequencer while using my Launchpad.
