### PR TITLE
Fix mixups of session stop buttons on multiple launchpads

### DIFF
--- a/SpecialSessionComponent.py
+++ b/SpecialSessionComponent.py
@@ -68,7 +68,7 @@ class SpecialSessionComponent(SessionComponent):
 
 	def _update_stop_clips_led(self, index):
 		if self.is_enabled() and self._stop_track_clip_buttons != None:
-			if index<len(self._stop_track_clip_buttons):
+			if index >= 0 and index<len(self._stop_track_clip_buttons):
 				button = self._stop_track_clip_buttons[index]
 				tracks_to_use = self.tracks_to_use()
 				track_index = index + self.track_offset()


### PR DESCRIPTION
I just didn't think of it while debugging and actually looking at the very output that should have told me what was going on a few days ago. I think work coding for 12h before I started has something to do with that..
The probable solution popped up immediately in my mind after I saw your just now and thought about the problem for ten seconds :). 