### PR TITLE
Code changes for note repeat in drum rack, add note repeat documentation

### DIFF
--- a/InstrumentControllerComponent.py
+++ b/InstrumentControllerComponent.py
@@ -193,7 +193,7 @@ class InstrumentControllerComponent(CompoundComponent):
 		if self.is_enabled() and not self._scales.is_enabled() and self._scales.is_quick_scale:
 			keys = ["C","C#","D","D#","E","F","F#","G","G#","A","A#","B"]
 			if ((value != 0) or (not is_momentary)):
-				if self._quick_scale_root==0:
+				if self._quick_scale_root==0 and not self._scales.is_drumrack:
 					root = -1
 					selected_key = self._scales._key
 					selected_modus = self._scales._modus
@@ -254,7 +254,7 @@ class InstrumentControllerComponent(CompoundComponent):
 								self._scales.update_object_name(self._track_controller.selected_clip)
 						self.update()
 
-				elif self._quick_scale_root==1:
+				elif self._quick_scale_root==1 and not self._scales.is_drumrack:
 					if(y == 0):
 						if x < 7 and self._quick_scales[x] != -1:
 							self._scales.set_modus(self._quick_scales[x])
@@ -475,10 +475,147 @@ class InstrumentControllerComponent(CompoundComponent):
 				button.set_channel(non_feedback_channel)
 				#button.force_next_send()
 
+			if self._scales.is_quick_scale:
+				
+				selected_modus = self._scales._modus
+				selected_key = self._scales._key
+
+				if self._quick_scale_root==0 and not self._scales.is_drumrack:
+					if selected_modus == 0 or selected_modus == 12:
+						key_color = "QuickScale.Major.Key"
+						fifth_button_color = "QuickScale.Major.CircleOfFifths"
+						mode_button_color = "QuickScale.Major.Mode"
+						relative_scale_button_color = "QuickScale.Major.RelativeScale"
+					elif selected_modus == 1 or selected_modus == 11:
+						key_color = "QuickScale.Minor.Key"
+						fifth_button_color = "QuickScale.Minor.CircleOfFifths"
+						mode_button_color = "QuickScale.Minor.Mode"
+						relative_scale_button_color = "QuickScale.Minor.RelativeScale"
+					else:
+						key_color = "QuickScale.Other.Key"
+						fifth_button_color = "QuickScale.Other.CircleOfFifths"
+						mode_button_color = "QuickScale.Other.Mode"
+						relative_scale_button_color = "QuickScale.Other.RelativeScale"
+
+					# circle of 5th nav right
+					button = self._matrix.get_button(7, 1)
+					button.set_light(fifth_button_color)
+					# circle of 5th nav left
+					button = self._matrix.get_button(6, 0)
+					button.set_light(fifth_button_color)
+					# mode button
+					button = self._matrix.get_button(7, 0)
+					button.set_light(mode_button_color)
+					# relative scale button
+					button = self._matrix.get_button(2, 0)
+					button.set_light(relative_scale_button_color)
+
+					for x in [0, 1, 3, 4, 5]:
+						button = self._matrix.get_button(x, 0)
+						button.set_enabled(True)
+						button.set_on_off_values(key_color)
+						#button.force_next_send()
+						if [0, 2, 4, 5, 7, 9, 11, 12][x] + 1 == selected_key:
+							button.turn_on()
+						else:
+							button.turn_off()
+
+					for x in [0, 1, 2, 3, 4, 5, 6]:
+						button = self._matrix.get_button(x, 1)
+						button.set_enabled(True)
+						button.set_on_off_values(key_color)
+						#button.force_next_send()
+						if [0, 2, 4, 5, 7, 9, 11, 12][x] == selected_key:
+							button.turn_on()
+						else:
+							button.turn_off()
+				elif self._quick_scale_root==1 and not self._scales.is_drumrack:
+					button = self._matrix.get_button(7, 0)
+					button.set_light("QuickScale.Major.Mode")
+					for x in range(7):
+						button = self._matrix.get_button(x, 0)
+						button.set_enabled(True)
+						if self._quick_scales[x] != -1:
+							button.set_on_off_values("QuickScale.Modus")
+							if self._quick_scales[x] == selected_modus:
+								button.turn_on()
+							else:
+								button.turn_off()
+							
+						else:
+							button.set_light("DefaultButton.Disabled")
+						
+					for x in range(8):
+						button = self._matrix.get_button(x, 1)
+						button.set_enabled(True)
+						if self._quick_scales[x + 7] != -1:
+							button.set_on_off_values("QuickScale.Modus")
+						else:
+							button.set_on_off_values("DefaultButton.Disabled", "DefaultButton.Disabled")
+						#button.force_next_send()
+						if self._quick_scales[x + 7] == selected_modus:
+							button.turn_on()
+						else:
+							button.turn_off()
+				else:
+					button = self._matrix.get_button(7, 0)
+					button.set_light("QuickScale.Quant.Mode")
+					
+					
+					for x in range(7):
+						button = self._matrix.get_button(x, 0)
+						button.set_enabled(True)
+						
+						if(x ==0):
+							button.set_on_off_values("QuickScale.Quant.On", "QuickScale.Quant.Off")
+							if(not self._swing_amount() ==0.0):
+								button.turn_on()
+							else:
+								button.turn_off()
+						elif(x ==1):
+							button.set_on_off_values("QuickScale.Quant.On", "QuickScale.Quant.Off")
+							if(self._swing_amount() < 0.98):
+								button.turn_on()
+							else:
+								button.turn_off()	
+							
+						elif(x ==2):
+							button.set_on_off_values("QuickScale.Quant.Straight", "DefaultButton.Disabled")
+							button.turn_on()
+						elif(x ==3):
+							button.set_on_off_values("QuickScale.Quant.Swing", "DefaultButton.Disabled")
+							button.turn_on()
+						elif(x ==4):
+							button.set_on_off_values("QuickScale.Quant.Dotted", "DefaultButton.Disabled")
+							button.turn_on()
+						elif(x ==5):
+							button.set_on_off_values("QuickScale.Quant.Flam", "DefaultButton.Disabled")
+							button.turn_on()								
+						
+						elif(x ==6):
+							button.set_on_off_values("QuickScale.NoteRepeater.On", "QuickScale.NoteRepeater.Off")
+							if(self._note_repeat.is_enabled()):
+								button.turn_on()
+							else:								
+								button.turn_off()
+						
+					for x in range(8):
+						button = self._matrix.get_button(x, 1)
+						button.set_enabled(True)
+						if(x%2==0):						
+							button.set_on_off_values("QuickScale.Quant.Selected", "QuickScale.Quant.Note")
+						else:
+							button.set_on_off_values("QuickScale.Quant.Selected", "QuickScale.Quant.Tripplet")
+
+						if (x) == self._note_repeat.freq_index():
+							button.turn_on()
+						else:
+							button.turn_off()
+
 			if self._scales.is_drumrack:
 
 				for button, (x, y) in self._matrix.iterbuttons():
-					if button:
+					if button and (not self._scales.is_quick_scale or y > 1):
 						note = 0
 						if(x < 4):
 							note = 12 * self._scales._octave + x + 4 * (7 - y)
@@ -503,145 +640,7 @@ class InstrumentControllerComponent(CompoundComponent):
 						#button.force_next_send()
 						#button.turn_off()
 
-			else:
-				if self._scales.is_quick_scale:
-					
-					selected_modus = self._scales._modus
-					selected_key = self._scales._key
-
-					if self._quick_scale_root==0:
-						if selected_modus == 0 or selected_modus == 12:
-							key_color = "QuickScale.Major.Key"
-							fifth_button_color = "QuickScale.Major.CircleOfFifths"
-							mode_button_color = "QuickScale.Major.Mode"
-							relative_scale_button_color = "QuickScale.Major.RelativeScale"
-						elif selected_modus == 1 or selected_modus == 11:
-							key_color = "QuickScale.Minor.Key"
-							fifth_button_color = "QuickScale.Minor.CircleOfFifths"
-							mode_button_color = "QuickScale.Minor.Mode"
-							relative_scale_button_color = "QuickScale.Minor.RelativeScale"
-						else:
-							key_color = "QuickScale.Other.Key"
-							fifth_button_color = "QuickScale.Other.CircleOfFifths"
-							mode_button_color = "QuickScale.Other.Mode"
-							relative_scale_button_color = "QuickScale.Other.RelativeScale"
-
-						# circle of 5th nav right
-						button = self._matrix.get_button(7, 1)
-						button.set_light(fifth_button_color)
-						# circle of 5th nav left
-						button = self._matrix.get_button(6, 0)
-						button.set_light(fifth_button_color)
-						# mode button
-						button = self._matrix.get_button(7, 0)
-						button.set_light(mode_button_color)
-						# relative scale button
-						button = self._matrix.get_button(2, 0)
-						button.set_light(relative_scale_button_color)
-
-						for x in [0, 1, 3, 4, 5]:
-							button = self._matrix.get_button(x, 0)
-							button.set_enabled(True)
-							button.set_on_off_values(key_color)
-							#button.force_next_send()
-							if [0, 2, 4, 5, 7, 9, 11, 12][x] + 1 == selected_key:
-								button.turn_on()
-							else:
-								button.turn_off()
-
-						for x in [0, 1, 2, 3, 4, 5, 6]:
-							button = self._matrix.get_button(x, 1)
-							button.set_enabled(True)
-							button.set_on_off_values(key_color)
-							#button.force_next_send()
-							if [0, 2, 4, 5, 7, 9, 11, 12][x] == selected_key:
-								button.turn_on()
-							else:
-								button.turn_off()
-					elif self._quick_scale_root==1:
-						button = self._matrix.get_button(7, 0)
-						button.set_light("QuickScale.Major.Mode")
-						for x in range(7):
-							button = self._matrix.get_button(x, 0)
-							button.set_enabled(True)
-							if self._quick_scales[x] != -1:
-								button.set_on_off_values("QuickScale.Modus")
-								if self._quick_scales[x] == selected_modus:
-									button.turn_on()
-								else:
-									button.turn_off()
-								
-							else:
-								button.set_light("DefaultButton.Disabled")
-							
-						for x in range(8):
-							button = self._matrix.get_button(x, 1)
-							button.set_enabled(True)
-							if self._quick_scales[x + 7] != -1:
-								button.set_on_off_values("QuickScale.Modus")
-							else:
-								button.set_on_off_values("DefaultButton.Disabled", "DefaultButton.Disabled")
-							#button.force_next_send()
-							if self._quick_scales[x + 7] == selected_modus:
-								button.turn_on()
-							else:
-								button.turn_off()
-					else:
-						button = self._matrix.get_button(7, 0)
-						button.set_light("QuickScale.Quant.Mode")
-						
-						
-						for x in range(7):
-							button = self._matrix.get_button(x, 0)
-							button.set_enabled(True)
-							
-							if(x ==0):
-								button.set_on_off_values("QuickScale.Quant.On", "QuickScale.Quant.Off")
-								if(not self._swing_amount() ==0.0):
-									button.turn_on()
-								else:
-									button.turn_off()
-							elif(x ==1):
-								button.set_on_off_values("QuickScale.Quant.On", "QuickScale.Quant.Off")
-								if(self._swing_amount() < 0.98):
-									button.turn_on()
-								else:
-									button.turn_off()	
-								
-							elif(x ==2):
-								button.set_on_off_values("QuickScale.Quant.Straight", "DefaultButton.Disabled")
-								button.turn_on()
-							elif(x ==3):
-								button.set_on_off_values("QuickScale.Quant.Swing", "DefaultButton.Disabled")
-								button.turn_on()
-							elif(x ==4):
-								button.set_on_off_values("QuickScale.Quant.Dotted", "DefaultButton.Disabled")
-								button.turn_on()
-							elif(x ==5):
-								button.set_on_off_values("QuickScale.Quant.Flam", "DefaultButton.Disabled")
-								button.turn_on()								
-							
-							elif(x ==6):
-								button.set_on_off_values("QuickScale.NoteRepeater.On", "QuickScale.NoteRepeater.Off")
-								if(self._note_repeat.is_enabled()):
-									button.turn_on()
-								else:								
-									button.turn_off()
-							
-						for x in range(8):
-							button = self._matrix.get_button(x, 1)
-							button.set_enabled(True)
-							if(x%2==0):						
-								button.set_on_off_values("QuickScale.Quant.Selected", "QuickScale.Quant.Note")
-							else:
-								button.set_on_off_values("QuickScale.Quant.Selected", "QuickScale.Quant.Tripplet")
-
-							if (x) == self._note_repeat.freq_index():
-								button.turn_on()
-							else:
-								button.turn_off()
-					
-					
+			else:	
 				pattern = self._scales.get_pattern()
 				max_j = self._matrix.width() - 1
 				a = 0

--- a/ScaleComponent.py
+++ b/ScaleComponent.py
@@ -217,7 +217,13 @@ class ScaleComponent(ControlSurfaceComponent):
 				
 				elif row==1:
 					if self.is_drumrack:
-						button.set_light("DefaultButton.Disabled")
+						if col==7:
+							if self._quick_scale:
+								button.set_light("Scale.QuickScale.On")
+							else:
+								button.set_light("Scale.QuickScale.Off")
+						else:
+							button.set_light("DefaultButton.Disabled")
 					else:
 						if col==0 or col==1 or col==3 or col==4 or col==5:
 							if self._key == self._white_notes_index[col]+1:
@@ -404,7 +410,7 @@ class ScaleComponent(ControlSurfaceComponent):
 					self.set_modus(selected_modus, message)
 					self.set_key(root, message)
 			#QuickScale
-			if y == 1 and x == 7 and not self.is_drumrack:
+			if y == 1 and x == 7: #and not self.is_drumrack:
 				self._quick_scale = not self._quick_scale
 				if self._quick_scale:
 					self._control_surface.show_message("Quick scale ON")

--- a/web/index.html
+++ b/web/index.html
@@ -343,7 +343,8 @@
 	<section>
 	<h4>quick scale modes</h4>
 	<p>if quick scale is activated (last button on the right on the 2nd row in scale edit mode), the two first rows of the launchpad allow you to quickly change the scale.</p>
-	<p>this shows the two first rows of the launchpad. the last button of the first row changes between root note selection and mode selection.</p>
+	<p>this shows the two first rows of the launchpad. the last button of the first row changes between root note selection, mode selection, and note repeat.</p>
+	<p>if in drumrack mode, this is the only quick scale mode</p>
 	<h5>root note</h5>
 	<p>in this mode you can select the root note of your scale. you can also quickly alternate between minor and major by pressing the button again</p>
 	<table class="launchpad">
@@ -371,7 +372,7 @@
 		</tr>
 	</table>
 
-	<h5>quick scale modes: modus</h5>
+	<h5>modus</h5>
 	<p>in this mode you can select the mode of your scale.</p>
 	<table class="launchpad">
 		<tr>
@@ -394,6 +395,33 @@
 			<td class="amber" title="Hungarian Minor">Hunga. Minor</td>
 			<td class="amber">Minor Gypsy</td>
 			<td class="amber">Spanish</td>
+			<td class="side amber"><div class="note">undo. long press to redo</div>undo</td>
+		</tr>
+	</table>
+
+	<h5>note repeat</h5>
+	<p>in this mode you can activate and configure note repeat.</p>
+	<table class="launchpad">
+		<tr>
+			<td class="green">Swing +2.5% </td>
+			<td class="green">Swing -2.5%</td>
+			<td class="red">Swing 0%</td>
+			<td class="red">Swing 25%</td>
+			<td class="green">Swing 50%</td>
+			<td class="green">Swing 75%</td>
+			<td class="amber">swing toggle</td>
+			<td class="green">scale / mode toggle</td>
+			<td class="side amber"><div class="note">enter scale edition mode</div>scale</td>
+		</tr>
+		<tr>
+			<td class="red">1/4</td>
+			<td class="red">1/4T</td>
+			<td class="red">1/8</td>
+			<td class="red">1/8T</td>
+			<td class="red">1/16</td>
+			<td class="red">1/16T</td>
+			<td class="red">1/32</td>
+			<td class="red">1/32T</td>
 			<td class="side amber"><div class="note">undo. long press to redo</div>undo</td>
 		</tr>
 	</table>


### PR DESCRIPTION
added ability to toggle quick scale (limited to note repeater) for drum rack mode, also updated documentation on note repeater function 😄 

I only have my Behringer CMD TOUCH TC64 (in Launchpad S emulation mode), so was only able to test all the different modes in that hardware.

Cheers