### PR TITLE
Map volume buttons to levels requested by user

### DIFF
--- a/Settings.py
+++ b/Settings.py
@@ -27,6 +27,7 @@ USER_MODES = [
 STEPSEQ__SAVE_SCALE = None
 INSTRUMENT__SAVE_SCALE = None
 
-
-
-
+# Map buttons to levels in volume slider. Exactly 7 values must be provided.
+# The lowest button is always set to -inf. Lowest supported value is -69 dB.
+# So far the values are not exact: -24 dB below equals -23.7 dB in Ableton.
+VOLUME_LEVELS = (6, 0, -6, -12, -18, -24, -42)

--- a/SubSelectorComponent.py
+++ b/SubSelectorComponent.py
@@ -1,11 +1,24 @@
+import math
 from _Framework.ModeSelectorComponent import ModeSelectorComponent
 from _Framework.ButtonElement import ButtonElement
 from _Framework.ButtonMatrixElement import ButtonMatrixElement
 from _Framework.SessionComponent import SessionComponent
 from SpecialMixerComponent import SpecialMixerComponent
-from PreciseButtonSliderElement import PreciseButtonSliderElement, SLIDER_MODE_VOLUME, SLIDER_MODE_PAN
+from PreciseButtonSliderElement import (
+	PreciseButtonSliderElement, SLIDER_MODE_VOLUME, SLIDER_MODE_PAN
+)
+from Settings import VOLUME_LEVELS
+
+
+def level_to_value(level):
+	if level >= -18:
+		return (level + 34) / 40.0
+	else:
+		return math.e ** (level / 23.4573) / 1.17234
+
+
 PAN_VALUE_MAP = (-1.0, -0.634921, -0.31746, 0.0, 0.0, 0.31746, 0.634921, 1.0)
-VOL_VALUE_MAP = (0.0, 0.142882, 0.302414, 0.4, 0.55, 0.7, 0.85, 1.0)
+VOL_VALUE_MAP = tuple(sorted([0.0] + [level_to_value(level) for level in VOLUME_LEVELS]))
 SEND_VALUE_MAP = (0.0, 0.103536, 0.164219, 0.238439, 0.343664, 0.55, 0.774942, 1.0)
 
 

--- a/web/index.html
+++ b/web/index.html
@@ -1355,6 +1355,10 @@
 
 	<section>
 	<h3>Mixer Mode</h3>
+	<h4>Volume</h4>
+	<p>
+		If you wish to override default mapping for volume slider buttons you can set it via <var>VOLUME_LEVELS</var> setting in "Settings.py" file.
+	</p>
 	<table class="launchpad">
 		<tr class="top">
 			<td class="green">prev scene</td>


### PR DESCRIPTION
This is improved version of https://github.com/hdavid/Launchpad95/pull/54 - values are set to default ones

I didn't touch the changelog as I thought you'd like to do that yourself.