### PR TITLE
changed Settings imports, added product id for Launchpad Mini

### DIFF
--- a/InstrumentControllerComponent.py
+++ b/InstrumentControllerComponent.py
@@ -11,7 +11,7 @@ except ImportError:
 	
 from .TrackControllerComponent import TrackControllerComponent
 from .ScaleComponent import ScaleComponent,CIRCLE_OF_FIFTHS,MUSICAL_MODES,KEY_NAMES
-from .Settings import *
+from .Settings import Settings
 
 
 class InstrumentControllerComponent(CompoundComponent):

--- a/InstrumentControllerComponent.py
+++ b/InstrumentControllerComponent.py
@@ -11,8 +11,10 @@ except ImportError:
 	
 from .TrackControllerComponent import TrackControllerComponent
 from .ScaleComponent import ScaleComponent,CIRCLE_OF_FIFTHS,MUSICAL_MODES,KEY_NAMES
-from .Settings import Settings
-
+try:
+    exec("from .Settings import Settings")
+except ImportError:
+    exec("from .Settings import *")
 
 class InstrumentControllerComponent(CompoundComponent):
 

--- a/Launchpad.py
+++ b/Launchpad.py
@@ -8,7 +8,7 @@ from .ConfigurableButtonElement import ConfigurableButtonElement
 from .MainSelectorComponent import MainSelectorComponent
 from .NoteRepeatComponent import NoteRepeatComponent
 from .M4LInterface import M4LInterface
-from .Settings import *
+from .Settings import Settings
 
 #fix for python3
 try:

--- a/Launchpad.py
+++ b/Launchpad.py
@@ -8,7 +8,10 @@ from .ConfigurableButtonElement import ConfigurableButtonElement
 from .MainSelectorComponent import MainSelectorComponent
 from .NoteRepeatComponent import NoteRepeatComponent
 from .M4LInterface import M4LInterface
-from .Settings import Settings
+try:
+    exec("from .Settings import Settings")
+except ImportError:
+    exec("from .Settings import *")
 
 #fix for python3
 try:

--- a/MainSelectorComponent.py
+++ b/MainSelectorComponent.py
@@ -10,8 +10,11 @@ from .InstrumentControllerComponent import InstrumentControllerComponent
 from .SubSelectorComponent import SubSelectorComponent  # noqa
 from .StepSequencerComponent import StepSequencerComponent
 from .StepSequencerComponent2 import StepSequencerComponent2
-from .Settings import Settings
 from .NoteRepeatComponent import NoteRepeatComponent
+try:
+    exec("from .Settings import Settings")
+except ImportError:
+    exec("from .Settings import *")
 
 class MainSelectorComponent(ModeSelectorComponent):
 

--- a/StepSequencerComponent.py
+++ b/StepSequencerComponent.py
@@ -12,7 +12,10 @@ from .NoteEditorComponent import NoteEditorComponent
 from .TrackControllerComponent import TrackControllerComponent
 import time
 from .ScaleComponent import ScaleComponent, MUSICAL_MODES, KEY_NAMES
-from .Settings import Settings
+try:
+    exec("from .Settings import Settings")
+except ImportError:
+    exec("from .Settings import *")
 
 # quantization button colours. this must remain of length 4.
 QUANTIZATION_MAP = [1, 0.5, 0.25, 0.125]  # 1/4 1/8 1/16 1/32

--- a/StepSequencerComponent.py
+++ b/StepSequencerComponent.py
@@ -11,8 +11,8 @@ except ImportError:
 from .NoteEditorComponent import NoteEditorComponent
 from .TrackControllerComponent import TrackControllerComponent
 import time
-from .Settings import *
 from .ScaleComponent import ScaleComponent, MUSICAL_MODES, KEY_NAMES
+from .Settings import Settings
 
 # quantization button colours. this must remain of length 4.
 QUANTIZATION_MAP = [1, 0.5, 0.25, 0.125]  # 1/4 1/8 1/16 1/32

--- a/SubSelectorComponent.py
+++ b/SubSelectorComponent.py
@@ -7,7 +7,10 @@ from .SpecialMixerComponent import SpecialMixerComponent
 from .PreciseButtonSliderElement import (
 	PreciseButtonSliderElement, SLIDER_MODE_VOLUME, SLIDER_MODE_PAN
 )
-from .Settings import Settings
+try:
+    exec("from .Settings import Settings")
+except ImportError:
+    exec("from .Settings import *")
 
 
 def level_to_value(level):

--- a/__init__.py
+++ b/__init__.py
@@ -8,20 +8,21 @@ def create_instance(c_instance):
 def get_capabilities():
 	return {
 		CONTROLLER_ID_KEY: controller_id(
-			vendor_id = 4661, 
+			vendor_id = 4661,
 			product_ids = [
 				14, # Lauchpad
+				54, # Launchpad Mini
 				105,# Launchpad ?
-				106,107,108,109, 110,111,112, 113,114,115,116, 117,118,119,120,
+				106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,
 				275,# Launchpad Mini MK3'
-				259 # launchpad X	
-			], 
-			model_name = 
+				259 # launchpad X
+			],
+			model_name =
 			[
-				'Launchpad', 
+				'Launchpad',
+				'Launchpad Mini',
 				'Launchpad S',
-				'Launchpad Mini',  
-				'Launchpad MK2', 
+				'Launchpad MK2',
 				'Launchpad MK2 2',
 				'Launchpad MK2 3',
 				'Launchpad MK2 4',
@@ -41,14 +42,14 @@ def get_capabilities():
 				'Launchpad X'
 			]
 		),
-		PORTS_KEY: 
+		PORTS_KEY:
 			[
 	            #inport(props=[NOTES_CC, SCRIPT]),
 	            #inport(props=[NOTES_CC, REMOTE]),
 	            #outport(props=[NOTES_CC, SYNC, SCRIPT]),
 	            #outport(props=[REMOTE])
-				inport(props = [NOTES_CC, REMOTE]), 
-				inport(props = [NOTES_CC, REMOTE, SCRIPT]), 
+				inport(props = [NOTES_CC, REMOTE]),
+				inport(props = [NOTES_CC, REMOTE, SCRIPT]),
 				outport(props = [NOTES_CC, SYNC, REMOTE]),
 				outport(props = [NOTES_CC, SYNC, REMOTE, SCRIPT])
 			]


### PR DESCRIPTION
The scripts were failing on Ableton Live 9 Suite (9.5 Build: 2015-10-20) with error:
```
3270 ms. RemoteScriptError: from .Settings import *

3270 ms. RemoteScriptError: SyntaxError
3270 ms. RemoteScriptError: :
3270 ms. RemoteScriptError: 'import *' not allowed with 'from .'
3270 ms. RemoteScriptError:
```

I've replaced all the places where it occurred in the source files, some of them already had the correct `from .Settings import Settings`.

In the process of trying to figure out why Launchpad95 wasn't showing in my Control Surfaces list I noticed the product id for my Launchpad Mini wasn't included, so I've added it for completeness. 
![Screen Shot 2021-04-07 at 1 12 40 PM](https://user-images.githubusercontent.com/6362025/113908106-2c624300-97a4-11eb-93dd-f834d7fd90f4.png)

My editor made a couple of extra trailing whitespace changes, feel free to ignore them.

(and possibly not the place for this, but thanks for the amazing scripts!)